### PR TITLE
fix: replace the Color type with RGB8

### DIFF
--- a/stm32f0-examples/examples/stm32f0_apa102_slider.rs
+++ b/stm32f0-examples/examples/stm32f0_apa102_slider.rs
@@ -14,7 +14,7 @@ use crate::hal::spi::Spi;
 use crate::hal::stm32;
 use cortex_m::peripheral::Peripherals;
 
-use smart_leds::{Color, SmartLedsWrite};
+use smart_leds::{RGB8, SmartLedsWrite};
 
 use cortex_m_rt::entry;
 
@@ -47,12 +47,12 @@ fn main() -> ! {
             &mut rcc,
         );
         const MAX: usize = 8;
-        const COLOR1: Color = Color {
+        const COLOR1: RGB8 = RGB8 {
             r: 0x00,
             g: 0xc3,
             b: 0x36,
         };
-        const COLOR2: Color = Color {
+        const COLOR2: RGB8 = RGB8 {
             r: 0x00,
             g: 0x24,
             b: 0xb0,

--- a/stm32f0-examples/examples/stm32f0_ws2812_spi_blink.rs
+++ b/stm32f0-examples/examples/stm32f0_ws2812_spi_blink.rs
@@ -14,7 +14,7 @@ use crate::hal::stm32;
 use crate::ws2812::Ws2812;
 use cortex_m::peripheral::Peripherals;
 
-use smart_leds::{Color, SmartLedsWrite};
+use smart_leds::{RGB8, SmartLedsWrite};
 
 use cortex_m_rt::entry;
 
@@ -47,21 +47,21 @@ fn main() -> ! {
             &mut rcc,
         );
 
-        let mut data: [Color; 3] = [Color::default(); 3];
-        let empty: [Color; 3] = [Color::default(); 3];
+        let mut data: [RGB8; 3] = [RGB8::default(); 3];
+        let empty: [RGB8; 3] = [RGB8::default(); 3];
         let mut ws = Ws2812::new(spi);
         loop {
-            data[0] = Color {
+            data[0] = RGB8 {
                 r: 0,
                 g: 0,
                 b: 0x10,
             };
-            data[1] = Color {
+            data[1] = RGB8 {
                 r: 0,
                 g: 0x10,
                 b: 0,
             };
-            data[2] = Color {
+            data[2] = RGB8 {
                 r: 0x10,
                 g: 0,
                 b: 0,

--- a/stm32f0-examples/examples/stm32f0_ws2812_spi_pre_slider.rs
+++ b/stm32f0-examples/examples/stm32f0_ws2812_spi_pre_slider.rs
@@ -14,7 +14,7 @@ use crate::hal::stm32;
 use crate::ws2812::prerendered::{Timing, Ws2812};
 use cortex_m::peripheral::Peripherals;
 
-use smart_leds::{Color, SmartLedsWrite};
+use smart_leds::{RGB8, SmartLedsWrite};
 
 use cortex_m_rt::entry;
 
@@ -49,12 +49,12 @@ fn main() -> ! {
             &mut rcc,
         );
         const MAX: usize = 8;
-        const COLOR1: Color = Color {
+        const COLOR1: RGB8 = RGB8 {
             r: 0x00,
             g: 0xc3 / 5,
             b: 0x36 / 5,
         };
-        const COLOR2: Color = Color {
+        const COLOR2: RGB8 = RGB8 {
             r: 0x00,
             g: 0x24 / 5,
             b: 0xb0 / 5,

--- a/stm32f0-examples/examples/stm32f0_ws2812_spi_slider.rs
+++ b/stm32f0-examples/examples/stm32f0_ws2812_spi_slider.rs
@@ -14,7 +14,7 @@ use crate::hal::stm32;
 use crate::ws2812::Ws2812;
 use cortex_m::peripheral::Peripherals;
 
-use smart_leds::{Color, SmartLedsWrite};
+use smart_leds::{RGB8, SmartLedsWrite};
 
 use cortex_m_rt::entry;
 
@@ -47,12 +47,12 @@ fn main() -> ! {
             &mut rcc,
         );
         const MAX: usize = 8;
-        const COLOR1: Color = Color {
+        const COLOR1: RGB8 = RGB8 {
             r: 0x00,
             g: 0xc3 / 5,
             b: 0x36 / 5,
         };
-        const COLOR2: Color = Color {
+        const COLOR2: RGB8 = RGB8 {
             r: 0x00,
             g: 0x24 / 5,
             b: 0xb0 / 5,

--- a/stm32f0-examples/examples/stm32f0_ws2812_timer_blink.rs
+++ b/stm32f0-examples/examples/stm32f0_ws2812_timer_blink.rs
@@ -15,7 +15,7 @@ use crate::hal::timers::*;
 use crate::ws2812::Ws2812;
 use cortex_m::peripheral::Peripherals;
 
-use smart_leds::{Color, SmartLedsWrite};
+use smart_leds::{RGB8, SmartLedsWrite};
 
 use cortex_m_rt::entry;
 
@@ -37,20 +37,20 @@ fn main() -> ! {
         let mut delay = Delay::new(cp.SYST, &mut rcc);
 
         let mut ws = Ws2812::new(timer, &mut ws_data_pin);
-        let mut data: [Color; 3] = [Color::default(); 3];
-        let empty: [Color; 3] = [Color::default(); 3];
+        let mut data: [RGB8; 3] = [RGB8::default(); 3];
+        let empty: [RGB8; 3] = [RGB8::default(); 3];
 
-        data[0] = Color {
+        data[0] = RGB8 {
             r: 0,
             g: 0,
             b: 0x10,
         };
-        data[1] = Color {
+        data[1] = RGB8 {
             r: 0,
             g: 0x10,
             b: 0,
         };
-        data[2] = Color {
+        data[2] = RGB8 {
             r: 0x10,
             g: 0,
             b: 0,

--- a/stm32f0-examples/examples/stm32f0_ws2812_timer_rainbow.rs
+++ b/stm32f0-examples/examples/stm32f0_ws2812_timer_rainbow.rs
@@ -15,7 +15,7 @@ use crate::hal::timers::*;
 use crate::ws2812::Ws2812;
 use cortex_m::peripheral::Peripherals;
 
-use smart_leds::{brightness, Color, SmartLedsWrite};
+use smart_leds::{brightness, RGB8, SmartLedsWrite};
 
 use cortex_m_rt::entry;
 
@@ -39,7 +39,7 @@ fn main() -> ! {
         let mut ws = Ws2812::new(timer, &mut ws_data_pin);
 
         const NUM_LEDS: usize = 10;
-        let mut data = [Color::default(); NUM_LEDS];
+        let mut data = [RGB8::default(); NUM_LEDS];
 
         loop {
             for j in 0..(256 * 5) {
@@ -58,7 +58,7 @@ fn main() -> ! {
 
 /// Input a value 0 to 255 to get a color value
 /// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> Color {
+fn wheel(mut wheel_pos: u8) -> RGB8 {
     wheel_pos = 255 - wheel_pos;
     if wheel_pos < 85 {
         return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();


### PR DESCRIPTION
I believe the Color type has been replaced with the RGB8 type.

I've not managed to make any LEDs blink yet, but I think this is a change that's required.