### PR TITLE
Update dependencies

### DIFF
--- a/avr-examples/Cargo.toml
+++ b/avr-examples/Cargo.toml
@@ -13,7 +13,7 @@ ws2812-spi = "0.4.0"
 
 [dependencies.arduino-leonardo]
 git = "https://github.com/Rahix/avr-hal"
-rev = "a22f9547100744b31053bab96c957270bd973cee"
+rev = "885e8ec6d6d2fe34f26a1e2697a99f41092f0985"
 
 # Configure the build for minimal size
 [profile.dev]

--- a/avr-examples/rust-toolchain.toml
+++ b/avr-examples/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2021-01-07"
+components = ["rust-src"]

--- a/lpc845-examples/Cargo.toml
+++ b/lpc845-examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 panic-rtt-target = {version = "0.1.1", features = ["cortex-m"]}
 rtt-target = {version = "0.3", features = ["cortex-m"]}
-lpc8xx-hal = {version = "0.8.2", features = ["845-rt"]}
+lpc8xx-hal = {version = "0.9", features = ["845-rt"]}
 smart-leds = "0.3.0"
 ws2812-spi = "0.4.0"
 

--- a/trinket-m0-examples/Cargo.toml
+++ b/trinket-m0-examples/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["David Sawatzke <david-sawatzke@users.noreply.github.com>"]
 edition = "2018"
 
 [dev-dependencies]
-trinket_m0 = { git = "https://github.com/atsamd-rs/atsamd/", features = ["unproven"]}
+trinket_m0 = { version = "0.9.0", features = ["unproven"]}
 embedded-hal = "0.2.3"
 bitbang-hal = "0.3.2"
 cortex-m-rt = "0.6"


### PR DESCRIPTION
Updates lpc8xx-hal and switches from git to the latest release for trinket_m0.
Also updates the git dependency for avr-hal and uses the newfangled `rust-toolchain.toml` file

The stm32f0-hal pull request remains unmerged, so no changes to that git dependency

