### PR TITLE
Fix Microbit example

### DIFF
--- a/microbit-v2-examples/.cargo/config
+++ b/microbit-v2-examples/.cargo/config
@@ -1,7 +1,7 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "gdb"
 rustflags = [
-    "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=-Tlink.x",
 ]
 
 [build]

--- a/microbit-v2-examples/Embed.toml
+++ b/microbit-v2-examples/Embed.toml
@@ -2,4 +2,4 @@
 chip = "nRF52833_xxAA"
 
 [default.rtt]
-enabled = true
+enabled = false

--- a/microbit-v2-examples/examples/microbit_v2_ws2812_spi_blink.rs
+++ b/microbit-v2-examples/examples/microbit_v2_ws2812_spi_blink.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
         miso: Some(miso),
         mosi: Some(mosi),
     };
-    let spi = spi::Spi::new(dp.SPI0, pins, spi::Frequency::M2, spi::MODE_0);
+    let spi = spi::Spi::new(dp.SPI0, pins, spi::Frequency::M4, spi::MODE_0);
 
     let mut ws = Ws2812::new(spi);
 


### PR DESCRIPTION
The SPI frequency of `spi::Frequency::M2` no longer works correctly.
Lights alternately flash all white instead of off.
Occasionally, the timing is off such that LEDs just flash white.

Increasing the SPI clock speed fixes the behavior of the LEDs.